### PR TITLE
GOM/cameras GPIO initialization fix

### DIFF
--- a/drivers/power/power_controller.py
+++ b/drivers/power/power_controller.py
@@ -81,9 +81,9 @@ OUT_SWITCH = 7
 #     '-----'
 #
 
-# pi outputs
-OUT_PI_COMMS = 11  # GPIO 17
-OUT_PI_SOLENOID_ENABLE = 40  # GPIO 21
+# GPIO outputs
+OUT_PI_COMMS = 17  # Physical pin 11
+OUT_PI_SOLENOID_ENABLE = 21  # Physical pin 40
 
 
 class PowerException(Exception):
@@ -114,7 +114,7 @@ class Power:
         self._dev = self._pi.i2c_open(bus, addr, flags)  # initialize i2c device
 
         # initialize pi outputs
-        GPIO.setmode(GPIO.BOARD)
+        GPIO.setmode(GPIO.BCM)
         GPIO.setup(OUT_PI_COMMS, GPIO.OUT)
         GPIO.setup(OUT_PI_SOLENOID_ENABLE, GPIO.OUT)
         GPIO.output(OUT_PI_COMMS, GPIO.LOW)


### PR DESCRIPTION
This PR fixes the  `GPIO.setmode` error observed during HITL testing. It seems to be caused by __init__.py files running while importing libraries used for communicating with our cameras which set the GPIO mode in the background. Fixed by:
- Changing the GPIO mode used by the gom driver to `BCM` instead of `BOARD`,  which stays consistent with the rest of the imported libraries

Has been tested on my personal pi with no GPIO errors, although not HITL tested. 