### PR TITLE
Changed the Solenoid enable pin from GPIO21 (pin 40) to GPIO13 (pin 33)

### DIFF
--- a/drivers/power/power_controller.py
+++ b/drivers/power/power_controller.py
@@ -79,7 +79,7 @@ OUT_SWITCH = 7
 
 # GPIO outputs
 OUT_PI_COMMS = 17  # Physical pin 11
-OUT_PI_SOLENOID_ENABLE = 21  # Physical pin 40
+OUT_PI_SOLENOID_ENABLE = 13  # Physical pin 33
 
 
 class PowerException(Exception):


### PR DESCRIPTION
This PR changes the ACS solenoid voltage boost enable pin from GPIO 21 to GPIO 13 in order to accommodate the NEMO wiring requirements.

Closes #27 
Signed-off-by: tmf97 <tmf97@cornell.edu>