### PR TITLE
Renamed burnwire2 to glowplug2

### DIFF
--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -153,7 +153,7 @@ class CommandDefinitions:
 
     def split(self):
         # for demo, delay of 0
-        self.parent.gom.burnwire2(self.parent.constants.SPLIT_BURNWIRE_DURATION, delay=0)
+        self.parent.gom.glowplug2(self.parent.constants.SPLIT_BURNWIRE_DURATION, delay=0)
         # Tell gom to power burnwires in five seconds
         # self.parent.gom.burnwire2(constants.SPLIT_BURNWIRE_DURATION, delay=5)
         # start reading gyro info
@@ -199,7 +199,7 @@ class CommandDefinitions:
     def separation_test(self):
         gyro_threader = Thread(target=self.gyro_thread)
         gyro_threader.start()
-        self.parent.gom.burnwire2(2)
+        self.parent.gom.glowplug2(2)
         gyro_threader.join()
 
     def gyro_thread(self):

--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -199,7 +199,7 @@ class CommandDefinitions:
     def separation_test(self):
         gyro_threader = Thread(target=self.gyro_thread)
         gyro_threader.start()
-        self.parent.gom.glowplug2(2)
+        self.parent.gom.burnwire1(2)
         gyro_threader.join()
 
     def gyro_thread(self):

--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -153,9 +153,9 @@ class CommandDefinitions:
 
     def split(self):
         # for demo, delay of 0
-        self.parent.gom.glowplug2(self.parent.constants.SPLIT_BURNWIRE_DURATION, delay=0)
+        self.parent.gom.burnwire1(self.parent.constants.SPLIT_BURNWIRE_DURATION, delay=0)
         # Tell gom to power burnwires in five seconds
-        # self.parent.gom.burnwire2(constants.SPLIT_BURNWIRE_DURATION, delay=5)
+        # self.parent.gom.burnwire1(constants.SPLIT_BURNWIRE_DURATION, delay=5)
         # start reading gyro info
         # read gyro rotation rate data after split - need to downlink these to make sure of successful split
 

--- a/drivers/gom.py
+++ b/drivers/gom.py
@@ -93,7 +93,7 @@ class Gomspace:
         """Turns on glowplug 2 for [duration] milliseconds after [delay] seconds. Does a display_all half way through"""
         # yes I know this is confusing that the glowplug function calls the burnwire functions - but it's just
         # turning on OUT-3 for a little bit.
-        self.gom.burnwire2(duration, delay)
+        self.gom.glowplug2(duration, delay)
 
     def set_electrolysis(self, status: bool, delay=0):
         """Switches on if [status] is true, off otherwise, with a delay of [delay] seconds."""

--- a/drivers/gom.py
+++ b/drivers/gom.py
@@ -90,7 +90,9 @@ class Gomspace:
         self.gom.burnwire1(duration, delay)
 
     def glowplug2(self, duration, delay=0):
-        """Turns on burnwire 2 for [duration] seconds after [delay] seconds. Does a display_all half way through"""
+        """Turns on glowplug 2 for [duration] milliseconds after [delay] seconds. Does a display_all half way through"""
+        # yes I know this is confusing that the glowplug function calls the burnwire functions - but it's just
+        # turning on OUT-3 for a little bit.
         self.gom.burnwire2(duration, delay)
 
     def set_electrolysis(self, status: bool, delay=0):

--- a/drivers/gom.py
+++ b/drivers/gom.py
@@ -89,7 +89,7 @@ class Gomspace:
         """Turns on burnwire 1 for [duration] seconds after [delay] seconds. Does a display_all half way through"""
         self.gom.burnwire1(duration, delay)
 
-    def burnwire2(self, duration, delay=0):
+    def glowplug2(self, duration, delay=0):
         """Turns on burnwire 2 for [duration] seconds after [delay] seconds. Does a display_all half way through"""
         self.gom.burnwire2(duration, delay)
 

--- a/drivers/power/HITL_testing/HITL_table_test.py
+++ b/drivers/power/HITL_testing/HITL_table_test.py
@@ -7,7 +7,7 @@ import time
 HITL_test = pc.Power()
 
 ps.gom_logger.debug("Turning off all outputs")
-OUTPUTS = ["comms", "burnwire_1", "burnwire_2", "glowplug", "solenoid", "electrolyzer"]
+OUTPUTS = ["comms", "burnwire_1", "glowplug_2", "glowplug", "solenoid", "electrolyzer"]
 for i in range(0, 6):
     HITL_test.set_single_output(OUTPUTS[i], 0, 0)
 

--- a/drivers/power/power_controller.py
+++ b/drivers/power/power_controller.py
@@ -450,7 +450,7 @@ class Power:
 
     # turns both burnwire 2 on for [duration] seconds, with a
     # delay of [delay] seconds.
-    def burnwire2(self, duration, delay=0):
+    def glowplug2(self, duration, delay=0):
         ps.gom_logger.info(
             "Turning on glowplug 2 for %s seconds after a delay of %s sec",
             duration,
@@ -458,11 +458,11 @@ class Power:
         )
 
         time.sleep(delay)
-        self.set_single_output("burnwire_2", 1, 0)
+        self.set_single_output("glowplug_2", 1, 0)
         time.sleep(duration * 0.001 / 2)
         self.displayAll()
         time.sleep(duration * 0.001 / 2)
-        self.set_single_output("burnwire_2", 0, 0)
+        self.set_single_output("glowplug_2", 0, 0)
 
     def comms(self, transmit):
         if transmit:

--- a/drivers/power/power_controller.py
+++ b/drivers/power/power_controller.py
@@ -452,16 +452,16 @@ class Power:
     # delay of [delay] seconds.
     def burnwire2(self, duration, delay=0):
         ps.gom_logger.info(
-            "Turning on burnwire 2 for %s seconds after a delay of %s sec",
+            "Turning on glowplug 2 for %s seconds after a delay of %s sec",
             duration,
             delay,
         )
 
         time.sleep(delay)
         self.set_single_output("burnwire_2", 1, 0)
-        time.sleep(duration / 2)
+        time.sleep(duration * 0.001 / 2)
         self.displayAll()
-        time.sleep(duration / 2)
+        time.sleep(duration * 0.001 / 2)
         self.set_single_output("burnwire_2", 0, 0)
 
     def comms(self, transmit):

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -81,7 +81,7 @@ class ConstantsEnum(IntEnum):
 class GomOutputs(IntEnum):
     comms = 0
     burnwire_1 = 1
-    burnwire_2 = 2
+    glowplug_2 = 2
     glowplug = 3
     solenoid = 4
     electrolyzer = 5


### PR DESCRIPTION
Closes #31 
A simple rename of the high-level gom drivers makes working with the new gom pi allocation easy, albeit a bit crude.
We now want to use OUT-3 for our second glowplug (instead of the second burnwire we originally wanted)

Signed-off-by: tmf97 <tmf97@cornell.edu>