### PR TITLE
Parmeter Reference Fixes

### DIFF
--- a/flight_modes/flight_mode.py
+++ b/flight_modes/flight_mode.py
@@ -36,6 +36,7 @@ from utils.constants import *
 from utils.log import get_log
 
 from utils.exceptions import UnknownFlightModeException
+import utils.parameters as params
 
 from communications.command_definitions import CommandDefinitions
 
@@ -102,14 +103,14 @@ class FlightMode:
 
         # if battery is low, go to low battery mode
         batt_percent = self.parent.telemetry.gom.percent
-        if (batt_percent < self.parent.parameters["ENTER_LOW_BATTERY_MODE_THRESHOLD"]) \
-                and not self.parent.parameters["IGNORE_LOW_BATTERY"]:
+        if (batt_percent < params.ENTER_LOW_BATTERY_MODE_THRESHOLD) \
+                and not params.IGNORE_LOW_BATTERY:
             return FMEnum.LowBatterySafety.value
 
         # if there is no current coming into the batteries, go to low battery mode
-        if sum(self.parent.telemetry.gom.hk.curin) < self.parent.parameters["ENTER_ECLIPSE_MODE_CURRENT"] \
-                and batt_percent < self.parent.parameters["ENTER_ECLIPSE_MODE_THRESHOLD"] \
-                and not self.parent.parameters["IGNORE_LOW_BATTERY"]:
+        if sum(self.parent.telemetry.gom.hk.curin) < params.ENTER_ECLIPSE_MODE_CURRENT \
+                and batt_percent < params.ENTER_ECLIPSE_MODE_THRESHOLD \
+                and not params.IGNORE_LOW_BATTERY:
             return FMEnum.LowBatterySafety.value
 
         # go to comms mode if there is something in the comms queue
@@ -335,15 +336,15 @@ class LowBatterySafetyMode(FlightMode):
     # TODO point solar panels directly at the sun
 
     def run_mode(self):
-        sleep(self.parent.parameters["LOW_BATT_MODE_SLEEP"])  # saves battery, maybe?
+        sleep(params.LOW_BATT_MODE_SLEEP)  # saves battery, maybe?
         raise NotImplementedError
 
     def update_state(self):
         # check power supply to see if I can transition back to NormalMode
-        if self.parent.telemetry.gom.percent > self.parent.parameters["EXIT_LOW_BATTERY_MODE_THRESHOLD"]:
+        if self.parent.telemetry.gom.percent > params.EXIT_LOW_BATTERY_MODE_THRESHOLD:
             self.parent.replace_flight_mode_by_id(FMEnum.Normal.value)
 
-        if sum(self.parent.telemetry.gom.hk.curin) > self.parent.parameters["ENTER_ECLIPSE_MODE_CURRENT"]:
+        if sum(self.parent.telemetry.gom.hk.curin) > params.ENTER_ECLIPSE_MODE_CURRENT:
             # If we do have some power coming in (i.e. we are not eclipsed by the moon/earth), reorient to face sun
             raise NotImplementedError
 
@@ -466,13 +467,13 @@ class NormalMode(FlightMode):
         if super_fm != NO_FM_CHANGE:
             return super_fm
 
-        time_for_opnav = (time() - self.parent.telemetry.opn.poll_time) // 60 < self.parent.parameters["OPNAV_INTERVAL"]
-        need_to_electrolyze = self.parent.telemetry.prs.pressure < self.parent.parameters["IDEAL_CRACKING_PRESSURE"]
+        time_for_opnav = (time() - self.parent.telemetry.opn.poll_time) // 60 < params.OPNAV_INTERVAL
+        need_to_electrolyze = self.parent.telemetry.prs.pressure < params.IDEAL_CRACKING_PRESSURE
         currently_electrolyzing = self.parent.telemetry.gom.is_electrolyzing
         seconds_to_electrolyze = 60  # TODO: actual calculation involving current pressure
 
         # if we don't want to electrolyze (per GS command), set need_to_electrolyze to false
-        need_to_electrolyze = need_to_electrolyze and self.parent.parameters["WANT_TO_ELECTROLYZE"]
+        need_to_electrolyze = need_to_electrolyze and params.WANT_TO_ELECTROLYZE
 
         # There's probably some super-optimized branchless way of implementing this logic, but oh well:
 

--- a/main.py
+++ b/main.py
@@ -132,8 +132,7 @@ class MainSatelliteThread(Thread):
         self.flight_mode.poll_inputs()
 
         # Telemetry downlink
-        if (datetime.today() - self.radio.last_telemetry_time).total_seconds() / 60 >= self.parameters[
-            "TELEM_DOWNLINK_TIME"]:
+        if (datetime.today() - self.radio.last_telemetry_time).total_seconds() / 60 >= utils.parameters.TELEM_DOWNLINK_TIME:
             self.enter_transmit_safe_mode()
             telemetry = self.command_definitions.gather_basic_telem()
             telem_downlink = (

--- a/telemetry/telemetry.py
+++ b/telemetry/telemetry.py
@@ -8,6 +8,7 @@ from drivers.power.power_structs import eps_hk_t, hkparam_t
 from utils.exceptions import PiSensorError, PressureError, GomSensorError, GyroError, ThermocoupleError
 from utils.db import GyroModel
 from utils.constants import MAX_GYRO_RATE, GomOutputs
+import utils.parameters as params
 
 
 def moving_average(x, w):
@@ -28,8 +29,8 @@ class GomSensor(SynchronousSensor):
         self.hk = self.parent.gom.get_health_data(level="eps")
         self.hkparam = self.parent.gom.get_health_data()
         battery_voltage = self.hk.vbatt  # mV
-        self.percent = (battery_voltage - self.parent.parameters['GOM_VOLTAGE_MIN']) / \
-                       (self.parent.parameters['GOM_VOLTAGE_MAX'] - self.parent.parameters['GOM_VOLTAGE_MIN'])
+        self.percent = (battery_voltage - params.GOM_VOLTAGE_MIN) / \
+                       (params.GOM_VOLTAGE_MAX - params.GOM_VOLTAGE_MIN)
         self.is_electrolyzing = bool(self.hk.output[GomOutputs.electrolyzer.value])
 
 


### PR DESCRIPTION
Adding a few quick fixes changing `main.parameters` dict references to `utils.parmeters` to get into master, so other branches can run main.py (nemo).

Thoughts @tmf97? If this doesn't work with your workflow, feel free to close.