### PR TITLE
Change NEMO reset_gpio_ch=16 in nemo.py __main__

### DIFF
--- a/drivers/nemo/nemo.py
+++ b/drivers/nemo/nemo.py
@@ -655,7 +655,7 @@ class Nemo(I2CDevice):
 
 
 if __name__ == "__main__":
-    nemo = Nemo()
+    nemo = Nemo(reset_gpio_ch=16)
 
     def print_config():
         """Get and print configuration"""


### PR DESCRIPTION
This makes it so nemo.py can be run as a standalone script. Kelly made this edit manually on oxygen, but adding to repo here so it doesn't get lost.