### PR TITLE
Add Pre-made Jira URL to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Summary
 <!-- What changes were made? What features were added? What bugs were fixed? -->
-This PR addresses Jira ticket CISLUNAR-     <!-- Add Jira ticket number here -->
+This PR addresses Jira ticket [CISLUNAR-XX](https://cislunarsoftware.atlassian.net/browse/CISLUNAR-XX)     <!-- Replace XX with JIRA ticket number -->
 
 
 


### PR DESCRIPTION
### Summary
Adds a pre-filled Jira URL into the PR template
No Jira ticket for this one, just my heart guiding me

### Testing
Eyeballing


### Notes
Hope this is useful

### Comments
- [ ] Add an x between the brackets if you commented your code well!

