### PR TITLE
Make maneuver test timings much shorter

### DIFF
--- a/tests/maneuver_test.py
+++ b/tests/maneuver_test.py
@@ -46,19 +46,19 @@ def test_maneuver_selection(m: MainSatelliteThread, mocker):
         consts.CommandEnum.ScheduleManeuver
     )
     m.command_handler.run_command(
-        maneuver_command, **{consts.MANEUVER_TIME: cur_time + 1000}
+        maneuver_command, **{consts.MANEUVER_TIME: cur_time + 6}
     )
     m.command_handler.run_command(
-        maneuver_command, **{consts.MANEUVER_TIME: cur_time + 100}
+        maneuver_command, **{consts.MANEUVER_TIME: cur_time + 2}
     )
 
     # m.command_definitions.schedule_maneuver(time=cur_time + 1000)
     # m.command_definitions.schedule_maneuver(time=cur_time + 100)
     assert len(m.maneuver_queue.queue) == 1
-    assert params.SCHEDULED_BURN_TIME == cur_time + 100
+    assert params.SCHEDULED_BURN_TIME == cur_time + 2
     m.flight_mode.run_mode()
     assert m.maneuver_queue.empty()
-    assert params.SCHEDULED_BURN_TIME == cur_time + 1000
+    assert params.SCHEDULED_BURN_TIME == cur_time + 6
     m.flight_mode.run_mode()
     assert m.maneuver_queue.empty()
     assert params.SCHEDULED_BURN_TIME == -1


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR addresses Jira ticket [CISLUNAR-103](https://cislunarsoftware.atlassian.net/browse/CISLUNAR-103)     <!-- Replace XX with JIRA ticket number -->
Decrease look ahead of maneuver test timings


### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
unit testing

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
Despite being unit tested earlier, we didn't see the 0-time-error occur until we flatsat test. Goes to show how even fully unit-tested code does not always mean you're free of bugs.

### Comments
- [x] Add an x between the brackets if you commented your code well!

