### PR TITLE
Pyright version revert

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,6 @@ jobs:
         run: |
           pytest
       - name: Run pyright
-        uses: jakebailey/pyright-action@v1.0.3
+        uses: jakebailey/pyright-action@v1.0.2
         with:
           version: 1.1.197

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,4 +27,6 @@ jobs:
         run: |
           pytest
       - name: Run pyright
-        uses: jakebailey/pyright-action@v1.0.2
+        uses: jakebailey/pyright-action@v1.0.3
+        with:
+          version: 1.1.197

--- a/communications/command_queue_writer.py
+++ b/communications/command_queue_writer.py
@@ -1,4 +1,4 @@
-"""command_queue_writer.py: a temporary workaround to not having functioning radio drivers. Instead of sending
+"""command_queue_writer.py: a workaround to not having a radio. Instead of sending
 commands to the EDU/HITL through the radio board, use this to write commands to a txt file, which is then read by
 main.py's read_command_queue_from_file method """
 


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
The lazy solution to [CISLUNAR-104](https://cislunarsoftware.atlassian.net/browse/CISLUNAR-104)     <!-- Replace XX with JIRA ticket number -->
Keeps the pyright version in CI to 1.1.197, 198 was released earlier today and caused all these errors.

### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
CI testing

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
I'm don't know how pyright works or what changed to cause these errors. Might be worth opening an issue over at https://github.com/microsoft/pyright, although getting a better understanding first would be good

### Comments
- [ ] Add an x between the brackets if you commented your code well!

