### PR TITLE
Replace all 'parent' with 'main'

### DIFF
--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from main import MainSatelliteThread
 # for an explanation of the above 4 lines of code, see
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
-# It lets your IDE know what type(parent) is, without causing any circular imports at runtime.
+# It lets your IDE know what type(main) is, without causing any circular imports at runtime.
 
 import drivers.power.power_structs as ps
 import time
@@ -39,9 +39,9 @@ class FM_Switch(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         logging.critical(f"Manual FM change commanded: {self.id}")
-        parent.replace_flight_mode_by_id(self.id)
+        main.replace_flight_mode_by_id(self.id)
 
 
 class BootSwitch(FM_Switch):
@@ -97,12 +97,12 @@ class separation_test(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        parent.gom.burnwire.pulse(consts.SPLIT_BURNWIRE_DURATION, asynchronous=True)
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        main.gom.burnwire.pulse(consts.SPLIT_BURNWIRE_DURATION, asynchronous=True)
         gyro_data = []
         logging.info("Reading Gyro data (rad/s)")
         for _ in range(1000):
-            gyro_reading = parent.gyro.get_gyro()
+            gyro_reading = main.gyro.get_gyro()
             gyro_time = time.time()
             gyro_list = list(gyro_reading)
             gyro_list.append(gyro_time)
@@ -119,9 +119,9 @@ class run_opnav(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         """Schedules Opnav mode into the FM queue"""
-        parent.FMQueue.put(FMEnum.OpNav)
+        main.FMQueue.put(FMEnum.OpNav)
 
 
 class exit_low_batt_thresh(Command):
@@ -132,7 +132,7 @@ class exit_low_batt_thresh(Command):
     uplink_codecs = [Codec(ck.VBATT, "ushort")]
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         value = kwargs[ck.VBATT]
         try:
             assert 6000 < value < 8400 and float(value) is float
@@ -150,7 +150,7 @@ class set_opnav_interval(Command):
     uplink_codecs = [Codec(ck.INTERVAL, "ushort")]
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         """Does the same thing as set_parameter, but only for the OPNAV_INTERVAL parameter. Only
             requires one kwarg and does some basic sanity checks on the passed value. Value is in minutes"""
         value = kwargs[ck.INTERVAL]
@@ -169,7 +169,7 @@ class set_opnav_interval(Command):
 #     assert 0 <= theta < 6.28318530718
 #     assert 0 <= phi < 3.14159265359
 #
-#     parent.reorientation_queue.put((theta, phi))
+#     main.reorientation_queue.put((theta, phi))
 
 
 class acs_pulse_timing(Command):
@@ -182,7 +182,7 @@ class acs_pulse_timing(Command):
     ]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         pulse_start_time = kwargs[ck.START]  # double, seconds
         pulse_duration = kwargs[ck.PULSE_DURATION]  # ushort, milliseconds
         pulse_num = kwargs[ck.PULSE_NUM]  # ushort, number
@@ -196,7 +196,7 @@ class acs_pulse_timing(Command):
         except AssertionError:
             raise CommandArgException
 
-        parent.reorientation_queue.put(
+        main.reorientation_queue.put(
             (pulse_start_time, pulse_duration, pulse_num, pulse_dt)
         )
 
@@ -212,10 +212,10 @@ class critical_telem(Command):
         codecs.GOM_PPT_MODE_codec,
     ]
 
-    def _method(self, parent: MainSatelliteThread, **kwargs):
+    def _method(self, main: MainSatelliteThread, **kwargs):
         # here we want to only gather the most critical telemetry values so that we spend the least electricity
         # downlinking them (think about a low-power scenario where the most important thing is our power in and out)
-        return parent.telemetry.minimal_packet()
+        return main.telemetry.minimal_packet()
 
 
 class basic_telem(Command):
@@ -248,10 +248,10 @@ class basic_telem(Command):
     ]
 
     def _method(
-        self, parent: MainSatelliteThread, **kwargs
+        self, main: MainSatelliteThread, **kwargs
     ) -> Dict[str, Union[float, int]]:
         # what's defined in section 3.6.1 of https://cornell.app.box.com/file/629596158344 would be a good packet
-        return parent.telemetry.standard_packet_dict()
+        return main.telemetry.standard_packet_dict()
 
 
 class detailed_telem(Command):
@@ -324,8 +324,8 @@ class detailed_telem(Command):
     ]
     # Needs validation
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> Dict[dk, int | float]:
-        return parent.telemetry.detailed_packet_dict()
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Dict[dk, int | float]:
+        return main.telemetry.detailed_packet_dict()
 
 
 class electrolysis(Command):
@@ -334,7 +334,7 @@ class electrolysis(Command):
     downlink_codecs = []
 
     # Needs validation
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         state = kwargs[ck.STATE]
         parameter_utils.set_parameter(
             "WANT_TO_ELECTROLYZE", bool(state), hard_set=False
@@ -349,7 +349,7 @@ class ignore_low_batt(Command):
     downlink_codecs = []
 
     # Needs validation
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         ignore = kwargs[ck.IGNORE]
         parameter_utils.set_parameter(
             "IGNORE_LOW_BATTERY", bool(ignore), hard_set=False
@@ -362,14 +362,14 @@ class schedule_maneuver(Command):
     downlink_codecs = []
 
     # Needs validation
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         time_burn = kwargs[ck.MANEUVER_TIME]
         logging.info("Scheduling a maneuver at: " + str(float(time_burn)))
         if params.SCHEDULED_BURN_TIME > 0:
-            parent.maneuver_queue.put(params.SCHEDULED_BURN_TIME)
-        parent.maneuver_queue.put(float(time_burn))
+            main.maneuver_queue.put(params.SCHEDULED_BURN_TIME)
+        main.maneuver_queue.put(float(time_burn))
 
-        smallest_time_burn = parent.maneuver_queue.get()
+        smallest_time_burn = main.maneuver_queue.get()
         parameter_utils.set_parameter(
             name="SCHEDULED_BURN_TIME",
             value=smallest_time_burn,
@@ -383,7 +383,7 @@ class reboot(Command):
     downlink_codecs = []
 
     # Needs validation
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         # TODO: make rebooting less janky
         os.system("sudo reboot")
         # add something here that adds to the restarts db that this restart was commanded
@@ -398,7 +398,7 @@ class cease_comms(Command):
     downlink_codecs = []
 
     # Needs validation
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         pword = kwargs[ck.PASSWORD]
         if pword == 123:  # TODO, change
             logging.critical("Ceasing all communications")
@@ -413,7 +413,7 @@ class set_system_time(Command):
 
     # Needs validation
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Dict[str, float]:
         # need to validate this works, and need to integrate updating RTC
         unix_epoch = kwargs[ck.SYS_TIME]
@@ -430,7 +430,7 @@ class get_param(Command):
     downlink_codecs = [Codec(dk.VALUE, "double")]
 
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Dict[str, float]:
         name = kwargs[ck.NAME]
         value = getattr(params, name)
@@ -443,8 +443,8 @@ class reboot_gom(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        parent.gom.driver.reboot()
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        main.gom.driver.reboot()
 
 
 class power_cycle(Command):
@@ -454,9 +454,9 @@ class power_cycle(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         # TODO: safe shutdown RPi before hard reset
-        parent.gom.hard_reset(True)
+        main.gom.hard_reset(True)
 
 
 class gom_outputs(Command):
@@ -468,14 +468,14 @@ class gom_outputs(Command):
     ]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         output_channel = kwargs[ck.OUTPUT_CHANNEL]
         # if 'state' is not found in kwargs, assume we want it to turn off
         state = kwargs.get(ck.STATE, 0)
         # if 'delay' is not found in kwargs, assume we want it immediately
         delay = kwargs.get(ck.DELAY, 0)
 
-        parent.gom.set_single_output(output_channel, int(state), delay=delay)
+        main.gom.set_single_output(output_channel, int(state), delay=delay)
 
 
 class pi_shutdown(Command):
@@ -483,7 +483,7 @@ class pi_shutdown(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         # TODO: do this more gracefully
         os.system("sudo poweroff")
 
@@ -495,7 +495,7 @@ class set_file_to_update(Command):
     uplink_codecs = [Codec(ck.FILE_PATH, "long_string")]
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         file_path = kwargs[ck.FILE_PATH]
         parameter_utils.set_parameter("FILE_UPDATE_PATH", file_path, False)
 
@@ -508,11 +508,11 @@ class add_file_block(Command):
     ]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         block_number = kwargs[ck.BLOCK_NUMBER]
         block_text = kwargs[ck.BLOCK_TEXT]
 
-        parent.file_block_bank[block_number] = block_text
+        main.file_block_bank[block_number] = block_text
 
         # TODO: Downlink acknowledgment with block number, or downlink block numbers on request
 
@@ -524,7 +524,7 @@ class get_file_blocks_info(Command):
     uplink_codecs = [Codec(ck.TOTAL_BLOCKS, "ushort")]
     downlink_codecs = [Codec(dk.CHECKSUM, "string"), Codec(dk.MISSING_BLOCKS, "string")]
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> Dict[str, str]:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Dict[str, str]:
         time.sleep(15)  # For testing only
 
         total_blocks = kwargs[ck.TOTAL_BLOCKS]
@@ -534,7 +534,7 @@ class get_file_blocks_info(Command):
         for i in range(total_blocks):
 
             try:
-                block = parent.file_block_bank[i]
+                block = main.file_block_bank[i]
                 full_file_text += block
 
             except KeyError:
@@ -550,17 +550,17 @@ class activate_file(Command):
     uplink_codecs = [Codec(ck.TOTAL_BLOCKS, "ushort")]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
         file_path = params.FILE_UPDATE_PATH
         total_blocks = kwargs[ck.TOTAL_BLOCKS]
 
-        assert total_blocks == len(parent.file_block_bank)
+        assert total_blocks == len(main.file_block_bank)
 
         full_file_text = ""
 
         # Assemble file from blocks
         for i in range(total_blocks):
-            full_file_text += parent.file_block_bank[i]
+            full_file_text += main.file_block_bank[i]
 
         # Create backup with the original if the file already exists
         if os.path.exists(file_path):
@@ -577,7 +577,7 @@ class activate_file(Command):
         original_file.seek(0)
         original_file.write(full_file_text)
 
-        parent.file_block_bank = {}
+        main.file_block_bank = {}
 
 
 class print_some_string(Command):
@@ -585,7 +585,7 @@ class print_some_string(Command):
     uplink_codecs = [Codec("some_number", "float"), Codec("long_string", "string")]
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         number = kwargs["some_number"]
         string = kwargs["long_string"]
 
@@ -598,12 +598,12 @@ class nemo_write_register(Command):
     uplink_codecs = [Codec(ck.REG_ADDRESS, "uint8"), Codec(ck.REG_VALUE, "uint8")]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
             reg_address = kwargs[ck.REG_ADDRESS]
             values = [kwargs[ck.REG_VALUE]]
 
-            parent.nemo_manager.write_register(reg_address, values)
+            main.nemo_manager.write_register(reg_address, values)
 
         else:
             logging.error(
@@ -616,11 +616,11 @@ class nemo_read_register(Command):
     uplink_codecs = [Codec(ck.REG_ADDRESS, "uint8"), Codec(ck.REG_SIZE, "uint8")]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
             reg_address = kwargs[ck.REG_ADDRESS]
             size = kwargs[ck.REG_SIZE]
-            parent.nemo_manager.read_register(reg_address, size)
+            main.nemo_manager.read_register(reg_address, size)
 
         else:
             logging.error(
@@ -652,9 +652,9 @@ class nemo_set_config(Command):
 
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
-            parent.nemo_manager.set_config(**kwargs)
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
+            main.nemo_manager.set_config(**kwargs)
 
         else:
             logging.error("CMD: nemo_set_config() failed, nemo_manager not initialized")
@@ -665,9 +665,9 @@ class nemo_power_off(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
-            parent.nemo_manager.power_off()
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
+            main.nemo_manager.power_off()
         else:
             logging.error("CMD: nemo_power_off() failed, nemo_manager not initialized")
 
@@ -677,9 +677,9 @@ class nemo_power_on(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
-            parent.nemo_manager.power_on()
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
+            main.nemo_manager.power_on()
 
         else:
             logging.error("CMD: nemo_power_on() failed, nemo_manager not initialized")
@@ -690,9 +690,9 @@ class nemo_reboot(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
-            parent.nemo_manager.reboot()
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
+            main.nemo_manager.reboot()
 
         else:
             logging.error("CMD: nemo_reboot() failed, nemo_manager not initialized")
@@ -703,14 +703,14 @@ class nemo_process_rate_data(Command):
     uplink_codecs = []
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
 
-        if parent.nemo_manager is not None:
+        if main.nemo_manager is not None:
             t_start = kwargs[ck.T_START]
             t_stop = kwargs[ck.T_STOP]
             decimation_factor = kwargs[ck.DECIMATION_FACTOR]
 
-            parent.nemo_manager.process_rate_data(t_start, t_stop, decimation_factor)
+            main.nemo_manager.process_rate_data(t_start, t_stop, decimation_factor)
 
         else:
             logging.error(
@@ -727,13 +727,13 @@ class nemo_process_histograms(Command):
     ]
     downlink_codecs = []
 
-    def _method(self, parent: MainSatelliteThread, **kwargs) -> None:
-        if parent.nemo_manager is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> None:
+        if main.nemo_manager is not None:
             t_start = kwargs[ck.T_START]
             t_stop = kwargs[ck.T_STOP]
             decimation_factor = kwargs[ck.DECIMATION_FACTOR]
 
-            parent.nemo_manager.process_histograms(t_start, t_stop, decimation_factor)
+            main.nemo_manager.process_histograms(t_start, t_stop, decimation_factor)
 
         else:
             logging.error(
@@ -757,7 +757,7 @@ class shellCommand(Command):
     downlink_codecs = RETURN_CODEC
 
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Dict[str, Union[float, int]]:
         cmd: str = cast("str", kwargs.get(ck.CMD))
         return_code = run_shell_command(cmd)
@@ -772,7 +772,7 @@ class sudoCommand(Command):
     downlink_codecs = RETURN_CODEC
 
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Dict[str, Union[float, int]]:
         cmd: str = cast("str", kwargs.get(ck.CMD))
         command = "sudo " + cmd
@@ -786,7 +786,7 @@ class picberry(Command):
     downlink_codecs = RETURN_CODEC
 
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Dict[str, Union[float, int]]:
         cmd: str = cast("str", kwargs.get(ck.CMD))
         base_command = "sudo picberry --gpio=20,21,16 --family=pic24fjxxxgb2xx "
@@ -800,7 +800,7 @@ class exec_py_file(Command):
     uplink_codecs = [Codec(ck.FNAME, "string")]
     downlink_codecs = []
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+    def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> None:
         filename: str = cast("str", kwargs[ck.FNAME])
         filename += ".py"
         logging.debug(f"CWD: {os.getcwd()}")
@@ -817,7 +817,7 @@ class set_param(Command):
 
     downlink_codecs = [Codec(dk.VALUE, "double")]
 
-    def _method(self, parent: MainSatelliteThread, **kwargs):
+    def _method(self, main: MainSatelliteThread, **kwargs):
         """Changes the values of a parameter in utils/parameters.py or .json if hard_set"""
         name = kwargs[ck.NAME]
         value = kwargs[ck.VALUE]
@@ -863,17 +863,15 @@ class set_gom_conf1(Command):
     uplink_codecs = GomConf1Codecs
     downlink_codecs = GomConf1Codecs
 
-    def _method(
-        self, parent: MainSatelliteThread, **kwargs
-    ) -> Optional[Dict[str, int]]:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Optional[Dict[str, int]]:
         new_config = gom_util.eps_config_from_dict(**kwargs)
         logging.info("New config to be set:")
         ps.displayConfig(new_config)
 
-        if parent.gom is not None:
+        if main.gom is not None:
             try:
-                parent.gom.driver.config_set(new_config)
-                updated_config: ps.eps_config_t = parent.gom.driver.config_get()
+                main.gom.driver.config_set(new_config)
+                updated_config: ps.eps_config_t = main.gom.driver.config_get()
                 new_config_dict = gom_util.dict_from_eps_config(updated_config)
                 return new_config_dict
 
@@ -889,12 +887,10 @@ class get_gom_conf1(Command):
     uplink_codecs = []
     downlink_codecs = GomConf1Codecs
 
-    def _method(
-        self, parent: MainSatelliteThread, **kwargs
-    ) -> Optional[Dict[str, int]]:
-        if parent.gom is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Optional[Dict[str, int]]:
+        if main.gom is not None:
             current_config: ps.eps_config_t = cast(
-                "ps.eps_config_t", parent.gom.get_health_data(level="config")
+                "ps.eps_config_t", main.gom.get_health_data(level="config")
             )
             ps.displayConfig(current_config)
             current_config_dict = gom_util.dict_from_eps_config(current_config)
@@ -916,15 +912,13 @@ class set_gom_conf2(Command):
     uplink_codecs = GomConf2Codecs
     downlink_codecs = GomConf2Codecs
 
-    def _method(
-        self, parent: MainSatelliteThread, **kwargs
-    ) -> Optional[Dict[str, int]]:
-        if parent.gom is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Optional[Dict[str, int]]:
+        if main.gom is not None:
             new_conf2 = gom_util.eps_config2_from_dict(kwargs)
-            parent.gom.driver.config2_set(new_conf2)
-            parent.gom.driver.config2_cmd(2)
+            main.gom.driver.config2_set(new_conf2)
+            main.gom.driver.config2_cmd(2)
 
-            return gom_util.dict_from_eps_config2(parent.gom.driver.config2_get())
+            return gom_util.dict_from_eps_config2(main.gom.driver.config2_get())
         else:
             logging.warning("Can't talk to Gom P31u")
 
@@ -934,12 +928,10 @@ class get_gom_conf2(Command):
     uplink_codecs = []
     downlink_codecs = GomConf2Codecs
 
-    def _method(
-        self, parent: MainSatelliteThread, **kwargs
-    ) -> Optional[Dict[str, int]]:
-        if parent.gom is not None:
+    def _method(self, main: MainSatelliteThread, **kwargs) -> Optional[Dict[str, int]]:
+        if main.gom is not None:
             current_conf2 = cast(
-                "ps.eps_config2_t", parent.gom.get_health_data(level="config2")
+                "ps.eps_config2_t", main.gom.get_health_data(level="config2")
             )
             ps.displayConfig2(current_conf2)
             current_config2_dict = gom_util.dict_from_eps_config2(current_conf2)
@@ -1034,7 +1026,7 @@ COMMAND_DICT: Dict[int, Command] = {command.id: command for command in COMMAND_L
 #     downlink_codecs = [Codec(CHECKSUM, "string"),
 #                      Codec(MISSING_BLOCKS, "string")]
 
-#     def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> Dict:
+#     def _method(self, main: Optional[MainSatelliteThread] = None, **kwargs) -> Dict:
 #         line_number = kwargs['line_number']
 #         new_line = kwargs['new_line']
 #         file_path = params.FILE_UPDATE_PATH
@@ -1057,44 +1049,44 @@ COMMAND_DICT: Dict[int, Command] = {command.id: command for command in COMMAND_L
 #         # tests integration of ADC into the rest of the FSW
 #         logging.info(
 #             "Cold junction temperature for gyro sensor in Celsius:")
-#         logging.info(parent.adc.get_gyro_temp())
+#         logging.info(main.adc.get_gyro_temp())
 
 #         logging.info(
-#             f"Pressure: {parent.adc.read_pressure()} psi")
+#             f"Pressure: {main.adc.read_pressure()} psi")
 #         logging.info(
-#             f"Temperature: {parent.adc.read_temperature()} deg C")
+#             f"Temperature: {main.adc.read_temperature()} deg C")
 
 #         logging.info("Conversion sanity check: 25.6 degrees")
-#         logging.info(parent.adc.convert_volt_to_temp(
-#             parent.adc.convert_temp_to_volt(25.6)))
+#         logging.info(main.adc.convert_volt_to_temp(
+#             main.adc.convert_temp_to_volt(25.6)))
 #         logging.info("Conversion sanity check: 2.023 mV")
-#         logging.info(parent.adc.convert_temp_to_volt(
-#             parent.adc.convert_volt_to_temp(2.023)))
+#         logging.info(main.adc.convert_temp_to_volt(
+#             main.adc.convert_volt_to_temp(2.023)))
 
 #     def rtc_test(self):
 #         logging.info(
-#             f"Oscillator Disabled: {parent.rtc.ds3231.disable_oscillator}")
-#         logging.info(f"RTC Temp: {parent.rtc.get_temp()}")
-#         logging.info(f"RTC Time: {parent.rtc.get_time()}")
+#             f"Oscillator Disabled: {main.rtc.ds3231.disable_oscillator}")
+#         logging.info(f"RTC Temp: {main.rtc.get_temp()}")
+#         logging.info(f"RTC Time: {main.rtc.get_time()}")
 #         # time.sleep(1)
 #         logging.info("Setting RTC time to 1e9")
-#         parent.rtc.set_time(int(1e9))
-#         logging.info("New RTC Time: {parent.rtc.get_time()}")
+#         main.rtc.set_time(int(1e9))
+#         logging.info("New RTC Time: {main.rtc.get_time()}")
 #         # time.sleep(1)
 #         logging.info("Incrementing RTC Time by 5555 seconds")
-#         parent.rtc.increment_rtc(5555)
+#         main.rtc.increment_rtc(5555)
 #         logging.info(
-#             f"New RTC Time: {parent.rtc.get_time()}")
+#             f"New RTC Time: {main.rtc.get_time()}")
 #         logging.info("Disabling Oscillator, waiting 10 seconds")
-#         # parent.rtc.disable_oscillator()
+#         # main.rtc.disable_oscillator()
 #         time.sleep(10)
 #         logging.info(
-#             f"RTC Time after disabling oscillator: {parent.rtc.get_time()}")
+#             f"RTC Time after disabling oscillator: {main.rtc.get_time()}")
 #         logging.info("Enabling Oscillator, waiting 10 seconds")
-#         # parent.rtc.enable_oscillator()
+#         # main.rtc.enable_oscillator()
 #         time.sleep(10)
 #         logging.info(
-#             f"RTC Time after re-enabling oscillator: {parent.rtc.get_time()}")
+#             f"RTC Time after re-enabling oscillator: {main.rtc.get_time()}")
 #         logging.info("Disabling Oscillator")
-#         # parent.rtc.disable_oscillator()
-#         parent.handle_sigint(None, None)
+#         # main.rtc.disable_oscillator()
+#         main.handle_sigint(None, None)

--- a/communications/command_handler.py
+++ b/communications/command_handler.py
@@ -52,11 +52,11 @@ class CommandHandler:
     downlink_counter: int  # how many times we've downlinked something
     # flag to do bit inflation; must be True for flight (if not done in Radio), can be False for testing
     inflation: bool
-    _parent: Optional[MainSatelliteThread] = None
+    _main: Optional[MainSatelliteThread] = None
 
-    def __init__(self, parent: Optional[MainSatelliteThread], inflation=False) -> None:
+    def __init__(self, main: Optional[MainSatelliteThread], inflation=False) -> None:
         self.inflation = inflation
-        self._parent = parent
+        self._main = main
         self.uplink_counter = params.UPLINK_COUNTER
         self.downlink_counter = params.DOWNLINK_COUNTER
 
@@ -179,7 +179,7 @@ class CommandHandler:
         return downlink
 
     def run_command(self, command: Command, kwargs: Dict[str, Union[int, float, str]]):
-        return command.run(parent=self._parent, **kwargs)
+        return command.run(main=self._main, **kwargs)
 
     def pack_telemetry(self, id, kwargs) -> bytes:
         telemetry_bytes = self.pack_link(False, self.downlink_counter, id, kwargs)

--- a/communications/commands.py
+++ b/communications/commands.py
@@ -17,7 +17,7 @@ class Command(ABC):
     If you want to implement a new command, go to command_definitions.py and add your command there.
     All you need to do if you want to implement a new command is to:
         1. Go to command_definitions.py and make a class inheriting from this class
-        2. Override the `self._method` method which can only take in a kwarg dictionary: no args other than `parent`
+        2. Override the `self._method` method which can only take in a kwarg dictionary: no args other than `main`
         3. Add the relevant Codecs - make sure you're unpacking and packing the dict correctly in self._method
         4. Specify the command's `id`. You'll need to add the id to the CommandEnum in utils.constants
         5. Add your new command class to the `COMMAND_LIST` defined at the bottom of command_definitions.py
@@ -45,7 +45,7 @@ class Command(ABC):
 
     @abstractmethod
     def _method(
-        self, parent: Optional[MainSatelliteThread] = None, **kwargs
+        self, main: Optional[MainSatelliteThread] = None, **kwargs
     ) -> Optional[Dict[str, Union[float, int]]]:
         ...
 
@@ -105,9 +105,9 @@ class Command(ABC):
             )
             raise CommandException
 
-    def run(self, parent: Optional[MainSatelliteThread] = None, **kwargs):
+    def run(self, main: Optional[MainSatelliteThread] = None, **kwargs):
         try:
-            downlink = self._method(parent=parent, **kwargs)
+            downlink = self._method(main=main, **kwargs)
             self.packing_check(downlink, self.downlink_codecs)
             return downlink
         except Exception as e:

--- a/flight_modes/attitude_adjustment.py
+++ b/flight_modes/attitude_adjustment.py
@@ -47,8 +47,8 @@ class AAMode(PauseBackgroundMode):
     command_codecs = {}
     command_arg_unpackers = {}
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         # Since we can't control the magnitude of our spin vector, we only car about the two angles (in spherical
         # coordinates) that define the direction of our spin vector, which saves us some up/downlink space.
         # data for if we want to do autonomous attitude adjustment
@@ -63,14 +63,11 @@ class AAMode(PauseBackgroundMode):
     # check if exit condition has completed
     def run_mode(self):
         # double check to make sure that we actually have the info we need to reorient:
-        if (
-            not self._parent.reorientation_queue.empty()
-            or self._parent.reorientation_list
-        ):
+        if not self._main.reorientation_queue.empty() or self._main.reorientation_list:
             # get relevant info from attitude adjustment queue
-            while not self._parent.reorientation_queue.empty():
-                self._parent.reorientation_list.append(
-                    self._parent.reorientation_queue.get()
+            while not self._main.reorientation_queue.empty():
+                self._main.reorientation_list.append(
+                    self._main.reorientation_queue.get()
                 )
 
             (
@@ -78,7 +75,7 @@ class AAMode(PauseBackgroundMode):
                 pulse_duration,
                 pulse_num,
                 pulse_dt,
-            ) = self._parent.reorientation_list[0]
+            ) = self._main.reorientation_list[0]
             logging.debug(
                 f"ACS start:{pulse_start}, duration:{pulse_duration}, num:{pulse_num}, dt:{pulse_dt}"
             )
@@ -99,7 +96,7 @@ class AAMode(PauseBackgroundMode):
                 self.missed_timing(pulse_start)
             else:
                 logging.debug(f"Sleeping {pulse_start - time()}s")
-                self._parent.gom.driver.calculate_solenoid_wave()
+                self._main.gom.driver.calculate_solenoid_wave()
                 sleep(max([(pulse_start - time()) - 2, 0]))
                 logging.info(
                     f"Experimental solenoid function. spike={params.ACS_SPIKE_DURATION}, hold={pulse_duration}"
@@ -107,8 +104,8 @@ class AAMode(PauseBackgroundMode):
                 # pulse ACS according to timings
                 for pulse_time in absolute_pulse_times:
                     sleep((pulse_time - time()) - (GOM_TIMING_FUDGE_FACTOR * 1e-3))
-                    self._parent.gom.driver.solenoid_single_wave(pulse_duration)
-            self._parent.reorientation_list.pop(0)
+                    self._main.gom.driver.solenoid_single_wave(pulse_duration)
+            self._main.reorientation_list.pop(0)
         else:
             logging.warning("No data for reorientation pulses found")
 
@@ -116,7 +113,7 @@ class AAMode(PauseBackgroundMode):
 
     def missed_timing(self, missed_pulse_timing):
         logging.error(f"Missed attitude adjustment maneuver at {missed_pulse_timing}")
-        # self._parent.communications_queue.put((ErrorCodeEnum.MissedPulse.value, missed_pulse_timing))
+        # self._main.communications_queue.put((ErrorCodeEnum.MissedPulse.value, missed_pulse_timing))
 
     # the methods defined below are for autonomous reorientation (i.e. we send the spacecraft a new spin vector and
     # it does all the math. However, due to our development timeline, we will have to fall back on calculating exact
@@ -124,18 +121,18 @@ class AAMode(PauseBackgroundMode):
     """
     def get_data(self):
         # get latest opnav location and gyro data
-        self._parent.tlm.opn.poll()
-        self.latest_opnav_quat = self._parent.tlm.opn.quat
-        self.latest_opnav_time = self._parent.tlm.opn.acq_time
+        self._main.tlm.opn.poll()
+        self.latest_opnav_quat = self._main.tlm.opn.quat
+        self.latest_opnav_time = self._main.tlm.opn.acq_time
         self.current_spin_vec = quat_to_rotvec(self.latest_opnav_quat)
-        self._parent.tlm.gyr.poll()
-        self._parent.tlm.gyr.write()
+        self._main.tlm.gyr.poll()
+        self._main.tlm.gyr.write()
 
-        while not self._parent.reorientation_queue.empty():
-            self._parent.reorientation_list.append(self._parent.reorientation_queue.get())
+        while not self._main.reorientation_queue.empty():
+            self._main.reorientation_list.append(self._main.reorientation_queue.get())
 
-        if self._parent.reorientation_list:
-            self.target_spin_vec = spherical_to_cartesian(*self._parent.reorientation_list[0])
+        if self._main.reorientation_list:
+            self.target_spin_vec = spherical_to_cartesian(*self._main.reorientation_list[0])
 
     def dead_reckoning(self) -> Tuple[Tuple[float, quaternion], Tuple[float, float, float]]:
         # Attempts to determine the current attitude of the spacecraft by integrating the gyros (prone to error) from
@@ -166,7 +163,7 @@ class AAMode(PauseBackgroundMode):
         cur_spin_vector = cur_quat.vec
         firing_vector_ECI = np.cross(cur_spin_vector, desired_spin_vector)
 
-        gyroz = self._parent.tlm.gyr.rot(2)
+        gyroz = self._main.tlm.gyr.rot(2)
 
         firing_vector_ECI *= gyroz / abs(gyroz)  # multiply by sign of z rotation rate to avoid sign error
         # firing_vector_ECI is the vector along which the vector from the CoM of the spacecraft to the ACS nozzle
@@ -183,12 +180,12 @@ class AAMode(PauseBackgroundMode):
 # If we want to do reorientations autonomously, the following would be an approach.
 # However, we are probably not doing this
 #
-outdated_opnav = (time() - self._parent.tlm.opn.acq_time) // 60 >= 15  # if opnav was run >15 minutes ago, rerun
-unfinished_opnav = not self._parent.tlm.opn.currently_running()
+outdated_opnav = (time() - self._main.tlm.opn.acq_time) // 60 >= 15  # if opnav was run >15 minutes ago, rerun
+unfinished_opnav = not self._main.tlm.opn.currently_running()
 
 if outdated_opnav or unfinished_opnav:
-    self._parent.FMQueue.put(FMEnum.OpNav.value)
-    self._parent.FMQueue.put(FMEnum.AttitudeAdjustment.value)
+    self._main.FMQueue.put(FMEnum.OpNav.value)
+    self._main.FMQueue.put(FMEnum.AttitudeAdjustment.value)
 else:
     # check if current orientation is within 10 degrees of desired orientation
     self.get_data()

--- a/flight_modes/flight_mode.py
+++ b/flight_modes/flight_mode.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
     # for an explanation of the above 4 lines of code, see
     # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
-    # It lets your IDE know what type(self._parent) is, without causing any circular imports at runtime.
+    # It lets your IDE know what type(self._main) is, without causing any circular imports at runtime.
 
 import gc
 from time import sleep, time
@@ -36,8 +36,8 @@ NO_ARGS = ([], 0)
 class FlightMode:
     flight_mode_id = -1  # Value overridden in FM's implementation
 
-    def __init__(self, parent: MainSatelliteThread):
-        self._parent = parent
+    def __init__(self, main: MainSatelliteThread):
+        self._main = main
         self.task_completed = False
 
     def update_state(self) -> int:
@@ -46,14 +46,14 @@ class FlightMode:
         this serves as a basis for which most other flight modes can build off of."""
 
         # I am not sure this will properly work, but shuld have little impact for software demo
-        if self._parent.opnav_process.is_alive():
+        if self._main.opnav_process.is_alive():
             try:
-                self._parent.opnav_process.join(timeout=1)
-                result = self._parent.opnav_proc_queue.get(timeout=1)
+                self._main.opnav_process.join(timeout=1)
+                result = self._main.opnav_proc_queue.get(timeout=1)
                 logging.info("[OPNAV]: ", result)
             except Empty:
-                if not self._parent.opnav_process.is_alive():
-                    self._parent.opnav_process.terminate()
+                if not self._main.opnav_process.is_alive():
+                    self._main.opnav_process.terminate()
                     logging.info("[OPNAV]: Process Terminated")
 
         flight_mode_id = self.flight_mode_id
@@ -65,7 +65,7 @@ class FlightMode:
             return flight_mode_id
 
         # go to maneuver mode if there is something in the maneuver queue
-        if not self._parent.maneuver_queue.empty() or params.SCHEDULED_BURN_TIME:
+        if not self._main.maneuver_queue.empty() or params.SCHEDULED_BURN_TIME:
             if params.SCHEDULED_BURN_TIME > time():
                 if params.SCHEDULED_BURN_TIME - time() < (60.0 * consts.BURN_WAIT_TIME):
                     return consts.FMEnum.Maneuver.value
@@ -76,17 +76,17 @@ class FlightMode:
 
         # go to reorientation mode if there is something in the reorientation queue
         if (
-            not self._parent.reorientation_queue.empty()
-        ) or self._parent.reorientation_list:
+            not self._main.reorientation_queue.empty()
+        ) or self._main.reorientation_list:
             return consts.FMEnum.AttitudeAdjustment.value
 
         # go to comms mode if there is something in the comms queue to downlink
 
-        if not self._parent.downlink_queue.empty():
+        if not self._main.downlink_queue.empty():
             return consts.FMEnum.CommsMode.value
 
         # if battery is low, go to low battery mode
-        batt_voltage = self._parent.telemetry.gom.hk.vbatt
+        batt_voltage = self._main.telemetry.gom.hk.vbatt
         if (
             batt_voltage < params.ENTER_LOW_BATTERY_MODE_THRESHOLD
         ) and not params.IGNORE_LOW_BATTERY:
@@ -94,17 +94,17 @@ class FlightMode:
 
         # if there is no current coming into the batteries, go to low battery mode
         if (
-            sum(self._parent.telemetry.gom.hk.curin) < params.ENTER_ECLIPSE_MODE_CURRENT
+            sum(self._main.telemetry.gom.hk.curin) < params.ENTER_ECLIPSE_MODE_CURRENT
             and batt_voltage < params.ENTER_ECLIPSE_MODE_THRESHOLD
             and not params.IGNORE_LOW_BATTERY
         ):
             return consts.FMEnum.LowBatterySafety.value
 
         if self.task_completed:
-            if self._parent.FMQueue.empty():
+            if self._main.FMQueue.empty():
                 return consts.FMEnum.Normal.value
             else:
-                return self._parent.FMQueue.get()
+                return self._main.FMQueue.get()
 
         # returns -1 if the logic here does not make any FM changes
         return consts.NO_FM_CHANGE
@@ -113,16 +113,16 @@ class FlightMode:
         raise NotImplementedError("Only implemented in specific flight mode subclasses")
 
     def execute_commands(self):
-        if len(self._parent.commands_to_execute) == 0:
+        if len(self._main.commands_to_execute) == 0:
             pass  # If I have no commands to execute do nothing
         else:
             # loop through commands in commands_to_execute list
             finished_commands = []
 
-            for command in self._parent.commands_to_execute:
-                downlink = self._parent.command_handler.execute_command(command)
+            for command in self._main.commands_to_execute:
+                downlink = self._main.command_handler.execute_command(command)
                 if downlink is not None:
-                    self._parent.downlink_queue.put(downlink)
+                    self._main.downlink_queue.put(downlink)
 
                 finished_commands.append(command)
 
@@ -133,15 +133,15 @@ class FlightMode:
             # TODO: Add try/except/finally statement above so that the for loop below always runs, even if an
             #  exception occurs in the above for loop
             for finished_command in finished_commands:
-                self._parent.commands_to_execute.remove(finished_command)
+                self._main.commands_to_execute.remove(finished_command)
 
     def poll_inputs(self):
         # TODO: Comment on what polling inputs means and how they differ across flight modes
-        if self._parent.gom is not None:
-            self._parent.gom.tick_wdt()  # FIXME; we don't want this for flight
+        if self._main.gom is not None:
+            self._main.gom.tick_wdt()  # FIXME; we don't want this for flight
             # The above line "pets" the dedicated watchdog timer on the GOMSpace P31u. This is an operational bug
             # An idea is to only pet the watchdog every time we recieve a command from the ground
-        self._parent.telemetry.poll()
+        self._main.telemetry.poll()
 
     def completed_task(self):
         self.task_completed = True
@@ -191,21 +191,21 @@ class PauseBackgroundMode(FlightMode):
     def run_mode(self):
         super().run_mode()
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def __enter__(self):
         super().__enter__()
-        if self._parent.nemo_manager is not None:
-            self._parent.nemo_manager.pause()
+        if self._main.nemo_manager is not None:
+            self._main.nemo_manager.pause()
         # TODO: Pause Opnav process if running
         gc.disable()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         gc.collect()
         gc.enable()
-        if self._parent.nemo_manager is not None:
-            self._parent.nemo_manager.resume()
+        if self._main.nemo_manager is not None:
+            self._main.nemo_manager.resume()
         # TODO: Resume Opnav process if previously running
         super().__exit__(exc_type, exc_val, exc_tb)
 
@@ -216,8 +216,8 @@ class TestMode(PauseBackgroundMode):
 
     flight_mode_id = consts.FMEnum.TestMode.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def update_state(self) -> int:
         # this is intentional - we don't want the FM to update if we are testing something
@@ -235,53 +235,53 @@ class CommsMode(FlightMode):
 
     flight_mode_id = consts.FMEnum.CommsMode.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.electrolyzing = False
 
     def enter_transmit_safe_mode(self):
 
         # Stop electrolyzing
-        if self._parent.gom.is_electrolyzing():
+        if self._main.gom.is_electrolyzing():
             self.electrolyzing = True
-            self._parent.gom.electrolyzers.set(False)
+            self._main.gom.electrolyzers.set(False)
 
         # Set RF receiving side to low
-        self._parent.gom.rf_rx.set(False)
+        self._main.gom.rf_rx.set(False)
 
         # Turn off LNA
-        self._parent.gom.lna.set(False)
+        self._main.gom.lna.set(False)
 
         # Set RF transmitting side to high
-        self._parent.gom.rf_tx.set(True)
+        self._main.gom.rf_tx.set(True)
 
         # Turn on power amplifier
-        self._parent.gom.power_amplifier.set(True)
+        self._main.gom.power_amplifier.set(True)
 
     def exit_transmit_safe_mode(self):
 
         # Turn off power amplifier
-        self._parent.gom.power_amplifier.set(False)
+        self._main.gom.power_amplifier.set(False)
 
         # Set RF transmitting side to low
-        self._parent.gom.rf_tx.set(False)
+        self._main.gom.rf_tx.set(False)
 
         # Turn on LNA
-        self._parent.gom.lna.set(True)
+        self._main.gom.lna.set(True)
 
         # Set RF receiving side to high
-        self._parent.gom.rf_rx.set(True)
+        self._main.gom.rf_rx.set(True)
 
         # Resume electrolysis if we paused it to transmit
         if self.electrolyzing:
-            self._parent.gom.electrolyzers.set(
+            self._main.gom.electrolyzers.set(
                 True, delay=params.DEFAULT_ELECTROLYSIS_DELAY
             )
 
     def execute_downlinks(self):
-        while not self._parent.downlink_queue.empty():
-            self._parent.radio.transmit(self._parent.downlink_queue.get())
-            self._parent.downlink_counter += 1
+        while not self._main.downlink_queue.empty():
+            self._main.radio.transmit(self._main.downlink_queue.get())
+            self._main.downlink_counter += 1
             # TODO: revisit and see if we actually need this
             sleep(params.DOWNLINK_BUFFER_TIME)
 
@@ -292,7 +292,7 @@ class CommsMode(FlightMode):
         return consts.NO_FM_CHANGE
 
     def run_mode(self):
-        if not self._parent.downlink_queue.empty():
+        if not self._main.downlink_queue.empty():
             self.enter_transmit_safe_mode()
             self.execute_downlinks()
             self.exit_transmit_safe_mode()
@@ -307,19 +307,19 @@ class OpNavMode(FlightMode):
     # TODO: Flight Software/Opnav interface
     flight_mode_id = consts.FMEnum.OpNav.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def run_mode(self):
         # TODO: overhaul so opnav calculation only occur while in opnav mode
-        if not self._parent.opnav_process.is_alive():
+        if not self._main.opnav_process.is_alive():
             logging.info("[OPNAV]: Able to run next opnav")
-            self._parent.last_opnav_run = time()
+            self._main.last_opnav_run = time()
             logging.info("[OPNAV]: Starting opnav subprocess")
-            self._parent.opnav_process = Process(
-                target=self.opnav_subprocess, args=(self._parent.opnav_proc_queue,)
+            self._main.opnav_process = Process(
+                target=self.opnav_subprocess, args=(self._main.opnav_proc_queue,)
             )
-            self._parent.opnav_process.start()
+            self._main.opnav_process.start()
         self.completed_task()
 
     def update_state(self) -> int:
@@ -351,8 +351,8 @@ class SensorMode(FlightMode):
 
     flight_mode_id = consts.FMEnum.SensorMode.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def update_state(self) -> int:
         return (
@@ -370,8 +370,8 @@ class SafeMode(FlightMode):
 
     flight_mode_id = consts.FMEnum.Safety.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def run_mode(self):
         # TODO
@@ -381,8 +381,8 @@ class SafeMode(FlightMode):
 class NormalMode(FlightMode):
     flight_mode_id = consts.FMEnum.Normal.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def poll_inputs(self):
         super().poll_inputs()
@@ -393,20 +393,20 @@ class NormalMode(FlightMode):
             return super_fm
 
         # since Normal mode never completes its task, we need to check the queue here instead of in super.update_state
-        if not self._parent.FMQueue.empty():
-            return self._parent.FMQueue.get()
+        if not self._main.FMQueue.empty():
+            return self._main.FMQueue.get()
 
         time_for_opnav: bool = (
-            time() - self._parent.last_opnav_run
+            time() - self._main.last_opnav_run
         ) // 60 > params.OPNAV_INTERVAL
 
         time_for_telem: bool = (
-            time() - self._parent.radio.last_transmit_time
+            time() - self._main.radio.last_transmit_time
         ) // 60 > params.TELEM_INTERVAL
 
-        need_to_electrolyze: bool = self._parent.telemetry.prs.pressure < params.IDEAL_CRACKING_PRESSURE
+        need_to_electrolyze: bool = self._main.telemetry.prs.pressure < params.IDEAL_CRACKING_PRESSURE
 
-        currently_electrolyzing = self._parent.telemetry.gom.is_electrolyzing
+        currently_electrolyzing = self._main.telemetry.gom.is_electrolyzing
 
         # if we don't want to electrolyze (per GS command), set need_to_electrolyze to false
         need_to_electrolyze = need_to_electrolyze and params.WANT_TO_ELECTROLYZE
@@ -417,7 +417,7 @@ class NormalMode(FlightMode):
         # if currently electrolyzing and over pressure, stop electrolyzing
         if currently_electrolyzing and not need_to_electrolyze:
             logging.info("No need to electrolyze, turning OFF electrolyzers")
-            self._parent.gom.electrolyzers.set(False)
+            self._main.gom.electrolyzers.set(False)
 
         if currently_electrolyzing and need_to_electrolyze:
             logging.debug("Already electrolyzing")
@@ -426,7 +426,7 @@ class NormalMode(FlightMode):
         # if below pressure and not electrolyzing, start electrolyzing
         if not currently_electrolyzing and need_to_electrolyze:
             logging.info("Not electrolyzing, turning ON electrolyzers")
-            self._parent.gom.electrolyzers.set(True)
+            self._main.gom.electrolyzers.set(True)
 
         if not currently_electrolyzing and not need_to_electrolyze:
             logging.debug("Electrolyzers already OFF")
@@ -436,15 +436,15 @@ class NormalMode(FlightMode):
 
         if time_for_opnav:
             logging.info("Time to run opnav")
-            self._parent.FMQueue.put(consts.FMEnum.OpNav.value)
+            self._main.FMQueue.put(consts.FMEnum.OpNav.value)
 
         if time_for_telem:
             # Add a standard packet to the downlink queue for our period telemetry beacon
-            telem = self._parent.telemetry.standard_packet_dict()
-            downlink = self._parent.command_handler.pack_telemetry(
+            telem = self._main.telemetry.standard_packet_dict()
+            downlink = self._main.command_handler.pack_telemetry(
                 consts.CommandEnum.BasicTelem, telem
             )
-            self._parent.downlink_queue.put(downlink)
+            self._main.downlink_queue.put(downlink)
             logging.info("Added a standard telemetry packet to the downlink queue")
 
         return consts.NO_FM_CHANGE
@@ -458,8 +458,8 @@ class CommandMode(PauseBackgroundMode):
 
     flight_mode_id = consts.FMEnum.Command.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def update_state(self) -> int:
         # DO NOT TICK THE WDT

--- a/flight_modes/low_battery.py
+++ b/flight_modes/low_battery.py
@@ -18,25 +18,25 @@ class LowBatterySafetyMode(FlightMode):
 
     flight_mode_id = FMEnum.LowBatterySafety.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def run_mode(self):
         if self.task_completed:
             sleep(params.LOW_BATT_MODE_SLEEP)  # saves battery, maybe?
             # TODO: not clear what this line is doing...
         else:
-            if self._parent.gom is not None:
+            if self._main.gom is not None:
                 # turn off all devices except for LNA. Most of this stuff is redundant, but better safe than sorry
-                self._parent.gom.power_amplifier.set(False)  # turn off PA loadswitch
-                self._parent.gom.rf_tx.set(False)  # Switch RF switch to RX
-                self._parent.gom.rf_rx.set(True)  # Switch RF switch to RX
+                self._main.gom.power_amplifier.set(False)  # turn off PA loadswitch
+                self._main.gom.rf_tx.set(False)  # Switch RF switch to RX
+                self._main.gom.rf_rx.set(True)  # Switch RF switch to RX
 
-                self._parent.gom.electrolyzers.set(False)  # stop electrolysis
-                self._parent.gom.burnwire.set(False)
-                self._parent.gom.glowplug_1.set(False)
-                self._parent.gom.glowplug_2.set(False)
-                self._parent.gom.solenoid.set(False)
+                self._main.gom.electrolyzers.set(False)  # stop electrolysis
+                self._main.gom.burnwire.set(False)
+                self._main.gom.glowplug_1.set(False)
+                self._main.gom.glowplug_2.set(False)
+                self._main.gom.solenoid.set(False)
 
             self.completed_task()
 
@@ -50,27 +50,27 @@ class LowBatterySafetyMode(FlightMode):
             return super_fm
 
         # check power supply to see if I can transition back to NormalMode
-        if self._parent.telemetry.gom.hk.vbatt > params.EXIT_LOW_BATTERY_MODE_THRESHOLD:
+        if self._main.telemetry.gom.hk.vbatt > params.EXIT_LOW_BATTERY_MODE_THRESHOLD:
             return FMEnum.Normal.value
 
         time_for_opnav = (
-            time() - self._parent.last_opnav_run
+            time() - self._main.last_opnav_run
         ) // 60 < params.LB_OPNAV_INTERVAL
 
         time_for_telem = (
-            time() - self._parent.radio.last_transmit_time
+            time() - self._main.radio.last_transmit_time
         ) // 60 < params.LB_TLM_INTERVAL
 
-        if time_for_opnav:  # TODO: and FMEnum.OpNav.value not in self._parent.FMQueue:
-            self._parent.FMQueue.put(FMEnum.OpNav.value)
+        if time_for_opnav:  # TODO: and FMEnum.OpNav.value not in self._main.FMQueue:
+            self._main.FMQueue.put(FMEnum.OpNav.value)
 
         if time_for_telem:
             # Add a minimal data packet to our periodic downlink beacon
-            telem = self._parent.telemetry.minimal_packet()
-            downlink = self._parent.command_handler.pack_telemetry(
+            telem = self._main.telemetry.minimal_packet()
+            downlink = self._main.command_handler.pack_telemetry(
                 CommandEnum.CritTelem, telem
             )
-            self._parent.downlink_queue.put(downlink)
+            self._main.downlink_queue.put(downlink)
             logging.info("Added a minimal data packet to our downlink")
 
         return NO_FM_CHANGE

--- a/flight_modes/maneuver_flightmode.py
+++ b/flight_modes/maneuver_flightmode.py
@@ -16,11 +16,11 @@ class ManeuverMode(PauseBackgroundMode):
 
     flight_mode_id = consts.FMEnum.Maneuver.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def get_pressure(self):
-        return self._parent.adc.read_pressure()
+        return self._main.adc.read_pressure()
 
     def valid_glowplug(self, current_pressure, prior_pressure):
         """Check pressure in place of acceleration for glowplug validation."""
@@ -55,7 +55,7 @@ class ManeuverMode(PauseBackgroundMode):
             logging.info(f"Pressure before firing: {prior_pressure} psi")
             if params.GLOWPLUG1_VALID:
                 logging.info("Trying glowplug 1")
-                self._parent.gom.glowplug_1.pulse(params.GLOWPLUG_DURATION)
+                self._main.gom.glowplug_1.pulse(params.GLOWPLUG_DURATION)
                 sleep(params.GLOW_WAIT_TIME)
                 current_pressure = self.get_pressure()
                 self.task_completed = self.valid_glowplug(
@@ -64,7 +64,7 @@ class ManeuverMode(PauseBackgroundMode):
                 set_parameter("GLOWPLUG1_VALID", self.task_completed, consts.FOR_FLIGHT)
             if not params.GLOWPLUG1_VALID and params.GLOWPLUG2_VALID:
                 logging.info("Trying glowplug 2")
-                self._parent.gom.glowplug_2.pulse(params.GLOWPLUG_DURATION)
+                self._main.gom.glowplug_2.pulse(params.GLOWPLUG_DURATION)
                 sleep(params.GLOW_WAIT_TIME)
                 current_pressure = self.get_pressure()
                 self.task_completed = self.valid_glowplug(
@@ -78,8 +78,8 @@ class ManeuverMode(PauseBackgroundMode):
 
         # prepare next maneuver
         smallest_time_burn = -1
-        while not self._parent.maneuver_queue.empty():
-            smallest_time_burn = self._parent.maneuver_queue.get()
+        while not self._main.maneuver_queue.empty():
+            smallest_time_burn = self._main.maneuver_queue.get()
             if smallest_time_burn < time():
                 # TODO send info to ground / store skipped in database
                 smallest_time_burn = -1

--- a/flight_modes/opnav_flightmode.py
+++ b/flight_modes/opnav_flightmode.py
@@ -14,8 +14,8 @@ class OpNavMode(PauseBackgroundMode):
     # FIXME: There is another class in flight mode with the same name that is in-use. This class is unused.
     flight_mode_id = FMEnum.OpNav.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.dummy_opnav_result = ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
 
     def set_return_val(self, returnval):
@@ -35,7 +35,7 @@ class OpNavMode(PauseBackgroundMode):
             self.most_recent_result, position_acquired_at
         )
         try:
-            session = self._parent.create_session()
+            session = self._main.create_session()
             session.add(opnav_model)
             session.commit()
         finally:
@@ -46,7 +46,7 @@ class OpNavMode(PauseBackgroundMode):
             return self.most_recent_result
         else:
             try:
-                session = self._parent.create_session()
+                session = self._main.create_session()
                 last_measurement = (
                     session.query(OpNavCoordinatesModel)
                     .order_by(OpNavCoordinatesModel.measurement_taken)
@@ -62,7 +62,7 @@ class OpNavMode(PauseBackgroundMode):
     def run_mode(self):
         if not self.opnav_process.is_alive():
             logging.info("[OPNAV]: Able to run next opnav")
-            self._parent.last_opnav_run = datetime.now()
+            self._main.last_opnav_run = datetime.now()
             logging.info("[OPNAV]: Starting opnav subprocess")
             self.opnav_process = Process(target=self.opnav_subprocess, args=())
             self.opnav_process.start()

--- a/flight_modes/restart_reboot.py
+++ b/flight_modes/restart_reboot.py
@@ -18,8 +18,8 @@ class BootUpMode(FlightMode):
     # this flight mode as stated in the documentation
     flight_mode_id = FMEnum.Boot.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
     def run_mode(self):
         logging.info("Boot up beginning...")
@@ -33,9 +33,9 @@ class BootUpMode(FlightMode):
         # deploy antennae
         # FIXME: differentiate between Hydrogen and Oxygen. Each satellite now has different required Bootup behaviors
         logging.info("Antennae deploy...")
-        self._parent.gom.burnwire.pulse(params.ANTENNAE_BURNWIRE_DURATION)
+        self._main.gom.burnwire.pulse(params.ANTENNAE_BURNWIRE_DURATION)
 
-        if self._parent.need_to_reboot:
+        if self._main.need_to_reboot:
             # TODO: double check the boot db history to make sure we aren't going into a boot loop
             # TODO: downlink something to let ground station know we're alive
             logging.critical("Rebooting to init cameras")
@@ -57,8 +57,8 @@ class RestartMode(FlightMode):
 
     flight_mode_id = FMEnum.Restart.value
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
 
         logging.info("Restarting...")
         create_session = create_sensor_tables_from_path(DB_FILE)
@@ -75,7 +75,7 @@ class RestartMode(FlightMode):
 
     # TODO implement error handling for if camera not detected
     def run_mode(self):
-        if self._parent.need_to_reboot:
+        if self._main.need_to_reboot:
             # TODO double check the boot db history to make sure we aren't going into a boot loop
             # TODO: downlink something to let ground station know we're alive and going to reboot
             logging.critical("Rebooting to init cameras")

--- a/telemetry/sensor.py
+++ b/telemetry/sensor.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from main import MainSatelliteThread
 # for an explanation of the above 4 lines of code, see
 # https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
-# It lets your IDE know what type(self._parent) is, without causing any circular imports at runtime.
+# It lets your IDE know what type(self._main) is, without causing any circular imports at runtime.
 
 from threading import Thread
 from time import time
@@ -22,10 +22,10 @@ from time import time
 class SynchronousSensor:
 
     # Initialize sensor
-    def __init__(self, parent: MainSatelliteThread):
-        # TODO: instead of initializing with parent, only use parent's driver object for each sensor.
+    def __init__(self, main: MainSatelliteThread):
+        # TODO: instead of initializing with main, only use main's driver object for each sensor.
         #  i.e. __init__(self, sensor: GyroSensor); self.sensor = sensor
-        self._parent = parent
+        self._main = main
         self.poll_time = -1.0
         # self.result = None
 

--- a/telemetry/telemetry.py
+++ b/telemetry/telemetry.py
@@ -47,23 +47,23 @@ def moving_average(x, w):
 
 
 class GomSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.hk = eps_hk_t()  # HouseKeeping data: eps_hk_t struct
         self.hkparam = hkparam_t()  # hkparam_t struct
         self.is_electrolyzing = bool()
 
     def poll(self):
         super().poll()
-        if self._parent.gom is not None:
-            self.hk = self._parent.gom.get_health_data(level="eps")
-            self.hkparam = self._parent.gom.get_health_data()
+        if self._main.gom is not None:
+            self.hk = self._main.gom.get_health_data(level="eps")
+            self.hkparam = self._main.gom.get_health_data()
             self.is_electrolyzing = bool(self.hk.output[GomOutputs.electrolyzer.value])
 
 
 class GyroSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.rot: Tuple[float, float, float] = (0.0, 0.0, 0.0)  # rad/s
         self.mag: Tuple[float, float, float] = (0.0, 0.0, 0.0)  # microTesla
         self.acc: Tuple[float, float, float] = (0.0, 0.0, 0.0)  # m/s^2
@@ -71,11 +71,11 @@ class GyroSensor(SynchronousSensor):
 
     def poll(self):
         super().poll()
-        if self._parent.gyro is not None:
-            self.rot = self._parent.gyro.get_gyro_corrected()
-            self.mag = self._parent.gyro.get_mag()
-            self.acc = self._parent.gyro.get_acceleration()
-            self.tmp = self._parent.gyro.get_temp()
+        if self._main.gyro is not None:
+            self.rot = self._main.gyro.get_gyro_corrected()
+            self.mag = self._main.gyro.get_mag()
+            self.acc = self._main.gyro.get_acceleration()
+            self.tmp = self._main.gyro.get_temp()
 
         # self.result = ImuResult(*self.rot, *self.mag, *self.acc)
 
@@ -85,7 +85,7 @@ class GyroSensor(SynchronousSensor):
         n_data = freq * duration
         data = []
         for _ in range(n_data):
-            data.append(self._parent.gyro.get_gyro_corrected())
+            data.append(self._main.gyro.get_gyro_corrected())
             sleep(1.0 / freq)
 
         data = np.asarray(data).T
@@ -115,7 +115,7 @@ class GyroSensor(SynchronousSensor):
         # gyro_model = GyroModel.from_tuple(gyro_tuple)
         #
         # try:
-        #     session = self._parent.create_session()
+        #     session = self._main.create_session()
         #     session.add(gyro_model)
         #     session.commit()
         # finally:
@@ -123,30 +123,30 @@ class GyroSensor(SynchronousSensor):
 
 
 class PressureSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.pressure = float()  # pressure, psi
 
     def poll(self):
         super().poll()
-        if self._parent.adc is not None:
-            self.pressure = self._parent.adc.read_pressure()
+        if self._main.adc is not None:
+            self.pressure = self._main.adc.read_pressure()
 
 
 class ThermocoupleSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.tmp = float()  # Fuel tank temperature, deg C
 
     def poll(self):
         super().poll()
-        if self._parent.adc is not None:
-            self.tmp = self._parent.adc.read_temperature()
+        if self._main.adc is not None:
+            self.tmp = self._main.adc.read_temperature()
 
 
 class PiSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.cpu: int = int()  # can be packed as short
         self.ram: int = int()  # can be packed as short
         self.disk: int = int()  # can be packed as short
@@ -176,19 +176,19 @@ class PiSensor(SynchronousSensor):
 
 
 class RtcSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.rtc_time = int()
 
     def poll(self):
         super().poll()
-        if self._parent.rtc is not None:
-            self.rtc_time = self._parent.rtc.get_time()
+        if self._main.rtc is not None:
+            self.rtc_time = self._main.rtc.get_time()
 
 
 class OpNavSensor(SynchronousSensor):
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, main):
+        super().__init__(main)
         self.quat = tuple() * 4
         self.pos = tuple() * 3
         self.acq_time = float()
@@ -198,18 +198,18 @@ class OpNavSensor(SynchronousSensor):
 
 
 class Telemetry(SynchronousSensor):
-    def __init__(self, parent):
-        # The purpose of the parent object is to ensure that only one object is defined for each sensor/component
-        # So almost all calls to sensors will be made through self._parent.<insert sensor stuff here>
-        super().__init__(parent)
+    def __init__(self, main):
+        # The purpose of the main object is to ensure that only one object is defined for each sensor/component
+        # So almost all calls to sensors will be made through self._main.<insert sensor stuff here>
+        super().__init__(main)
 
-        self.gom = GomSensor(parent)
-        self.gyr = GyroSensor(parent)
-        self.prs = PressureSensor(parent)
-        self.thm = ThermocoupleSensor(parent)
-        self.rpi = PiSensor(parent)
-        self.rtc = RtcSensor(parent)
-        self.opn = OpNavSensor(parent)
+        self.gom = GomSensor(main)
+        self.gyr = GyroSensor(main)
+        self.prs = PressureSensor(main)
+        self.thm = ThermocoupleSensor(main)
+        self.rpi = PiSensor(main)
+        self.rtc = RtcSensor(main)
+        self.opn = OpNavSensor(main)
 
         self.sensors = [self.gom, self.gyr, self.prs, self.thm, self.rpi, self.rtc]
 


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR solves a confusion issue. A lot of objects take in the `MainSatelliteThread` object as a `parent` in order to access other parts of FSW, but there is no inherent parent-child relationship in any of these uses. This PR renames all relevent `parent` objects gets renamed it `main`.

### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
Existing unit tests

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
We do have a circular dependency for most of the objects that take in a `MainSatelliteThread` object, which is pointing to an architectural issue that we should resolve. I have some ideas on this I'd like to discuss eventually. 

### Comments
- [ ] Add an x between the brackets if you commented your code well!

