### PR TITLE
New command implementation

### DIFF
--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -357,20 +357,42 @@ class ignore_low_batt(Command):
         )
 
 
-class reduce_ems_percentage_thresh(Command):
-    """ Reduces Earth, Sun, Moon Percentage threshold by factor of 2.
-        Useful for testing purposes when needing to reduce the confidence of
+class change_ems_percentage_thresh(Command):
+    """ Changes Earth, Sun, Moon Percentage threshold.
+        Useful for testing purposes when needing to reduce/increase the confidence of
         the body in find_with_hough_transform_and_contours.findBody()"""
 
     id = CommandEnum.SetEMSThresh
-    uplink_codecs = [Codec(ck.ignore, "float")]
-    downlink_codecs = []
+    uplink_codecs = [
+        Codec(ck.EARTH_THRESH, "float"),
+        Codec(ck.MOON_THRESH, "float"),
+        Codec(ck.SUN_THRESH, "float"),
+    ]
+    downlink_codecs = [
+        Codec(ck.EARTH_THRESH, "float"),
+        Codec(ck.MOON_THRESH, "float"),
+        Codec(ck.SUN_THRESH, "float"),
+    ]
 
-    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
-        # Use of kwargs?
-        parameter_utils.set_parameter("EARTH_PERCENTAGE_THRESH", 0.07, hard_set=False)
-        parameter_utils.set_parameter("MOON_PERCENTAGE_THRESH", 0.02, hard_set=False)
-        parameter_utils.set_parameter("SUN_PERCENTAGE_THRESH", 0.06, hard_set=False)
+    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs):
+        new_earth_thresh = kwargs[ck.EARTH_THRESH]
+        new_moon_thresh = kwargs[ck.MOON_THRESH]
+        new_sun_thresh = kwargs[ck.SUN_THRESH]
+        parameter_utils.set_parameter(
+            "EARTH_PERCENTAGE_THRESH", new_earth_thresh, hard_set=False
+        )
+        parameter_utils.set_parameter(
+            "MOON_PERCENTAGE_THRESH", new_moon_thresh, hard_set=False
+        )
+        parameter_utils.set_parameter(
+            "SUN_PERCENTAGE_THRESH", new_sun_thresh, hard_set=False
+        )
+
+        return {
+            ck.EARTH_THRESH: new_earth_thresh,
+            ck.MOON_THRESH: new_moon_thresh,
+            ck.SUN_THRESH: new_sun_thresh,
+        }
 
 
 class schedule_maneuver(Command):
@@ -980,7 +1002,7 @@ COMMAND_LIST: List[Command] = [
     detailed_telem(),
     electrolysis(),
     ignore_low_batt(),
-    reduce_ems_percentage_thresh(),
+    change_ems_percentage_thresh(),
     schedule_maneuver(),
     reboot(),
     cease_comms(),

--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -360,7 +360,8 @@ class ignore_low_batt(Command):
 class change_ems_percentage_thresh(Command):
     """ Changes Earth, Sun, Moon Percentage threshold.
         Useful for testing purposes when needing to reduce/increase the confidence of
-        the body in find_with_hough_transform_and_contours.findBody()"""
+        the body in find_with_hough_transform_and_contours.findBody()
+        Requires: Threshhold values must be between 0...1"""
 
     id = CommandEnum.SetEMSThresh
     uplink_codecs = [
@@ -378,6 +379,9 @@ class change_ems_percentage_thresh(Command):
         new_earth_thresh = kwargs[ck.EARTH_THRESH]
         new_moon_thresh = kwargs[ck.MOON_THRESH]
         new_sun_thresh = kwargs[ck.SUN_THRESH]
+        assert new_earth_thresh <= 1 and new_earth_thresh >= 0
+        assert new_moon_thresh <= 1 and new_moon_thresh >= 0
+        assert new_sun_thresh <= 1 and new_sun_thresh >= 0
         parameter_utils.set_parameter(
             "EARTH_PERCENTAGE_THRESH", new_earth_thresh, hard_set=False
         )

--- a/communications/command_definitions.py
+++ b/communications/command_definitions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+
 from communications.codec import Codec
 from communications.commands import Command
 from communications import codecs
@@ -354,6 +355,22 @@ class ignore_low_batt(Command):
         parameter_utils.set_parameter(
             "IGNORE_LOW_BATTERY", bool(ignore), hard_set=False
         )
+
+
+class reduce_ems_percentage_thresh(Command):
+    """ Reduces Earth, Sun, Moon Percentage threshold by factor of 2.
+        Useful for testing purposes when needing to reduce the confidence of
+        the body in find_with_hough_transform_and_contours.findBody()"""
+
+    id = CommandEnum.SetEMSThresh
+    uplink_codecs = [Codec(ck.ignore, "float")]
+    downlink_codecs = []
+
+    def _method(self, parent: Optional[MainSatelliteThread] = None, **kwargs) -> None:
+        # Use of kwargs?
+        parameter_utils.set_parameter("EARTH_PERCENTAGE_THRESH", 0.07, hard_set=False)
+        parameter_utils.set_parameter("MOON_PERCENTAGE_THRESH", 0.02, hard_set=False)
+        parameter_utils.set_parameter("SUN_PERCENTAGE_THRESH", 0.06, hard_set=False)
 
 
 class schedule_maneuver(Command):
@@ -963,6 +980,7 @@ COMMAND_LIST: List[Command] = [
     detailed_telem(),
     electrolysis(),
     ignore_low_batt(),
+    reduce_ems_percentage_thresh(),
     schedule_maneuver(),
     reboot(),
     cease_comms(),

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -49,6 +49,8 @@ class CommandTest(unittest.TestCase):
         self.assertEqual(downlink_args[ck.VALUE], new_value)
 
     def test_setEMSThresh(self):
+        """Tests whether we can succesfully change the threshold percentage values for the Earth,Sun,Moon """
+
         new_earth_thresh = 0.07
         new_moon_thresh = 0.025
         new_sun_thresh = 0.06

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -70,12 +70,12 @@ class CommandTest(unittest.TestCase):
         self.assertAlmostEqual(params.SUN_PERCENTAGE_THRESH, new_sun_thresh, 2)
 
         # Checking downlink
-        # downlink = self.sat.downlink_queue.get()
-        # downlink_command, downlink_args = self.ground_station.unpack_telemetry(downlink)
-        # self.assertEqual(downlink_command.id, CommandEnum.SetEMSThresh)
-        # self.assertEqual(downlink_args[ck.EARTH_THRESH], new_earth_thresh)
-        # self.assertEqual(downlink_args[ck.MOON_THRESH], new_moon_thresh)
-        # self.assertEqual(downlink_args[ck.SUN_THRESH], new_sun_thresh)
+        downlink = self.sat.downlink_queue.get()
+        downlink_command, downlink_args = self.ground_station.unpack_telemetry(downlink)
+        self.assertEqual(downlink_command.id, CommandEnum.SetEMSThresh)
+        self.assertAlmostEqual(downlink_args[ck.EARTH_THRESH], new_earth_thresh)
+        self.assertAlmostEqual(downlink_args[ck.MOON_THRESH], new_moon_thresh)
+        self.assertAlmostEqual(downlink_args[ck.SUN_THRESH], new_sun_thresh)
 
     def test_manual_fm_commands(self):
         """Commands the spacecraft to go into every flight mode """

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -48,6 +48,35 @@ class CommandTest(unittest.TestCase):
         self.assertEqual(downlink_command.id, CommandEnum.SetParam)
         self.assertEqual(downlink_args[ck.VALUE], new_value)
 
+    def test_setEMSThresh(self):
+        new_earth_thresh = 0.07
+        new_moon_thresh = 0.025
+        new_sun_thresh = 0.06
+
+        cmd = self.ground_station.pack_command(
+            CommandEnum.SetEMSThresh,
+            {
+                ck.EARTH_THRESH: new_earth_thresh,
+                ck.MOON_THRESH: new_moon_thresh,
+                ck.SUN_THRESH: new_sun_thresh,
+            },
+        )
+
+        # Checking uplink
+        self.sat.command_queue.put(cmd)
+        self.sat.execute_commands()
+        self.assertAlmostEqual(params.EARTH_PERCENTAGE_THRESH, new_earth_thresh, 3)
+        self.assertAlmostEqual(params.MOON_PERCENTAGE_THRESH, new_moon_thresh, 3)
+        self.assertAlmostEqual(params.SUN_PERCENTAGE_THRESH, new_sun_thresh, 2)
+
+        # Checking downlink
+        # downlink = self.sat.downlink_queue.get()
+        # downlink_command, downlink_args = self.ground_station.unpack_telemetry(downlink)
+        # self.assertEqual(downlink_command.id, CommandEnum.SetEMSThresh)
+        # self.assertEqual(downlink_args[ck.EARTH_THRESH], new_earth_thresh)
+        # self.assertEqual(downlink_args[ck.MOON_THRESH], new_moon_thresh)
+        # self.assertEqual(downlink_args[ck.SUN_THRESH], new_sun_thresh)
+
     def test_manual_fm_commands(self):
         """Commands the spacecraft to go into every flight mode """
         for mode in FMEnum:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -137,6 +137,10 @@ class CommandKwargs(StringEnum):
     IGNORE = "ignore"
     PASSWORD = "password"
 
+    EARTH_THRESH = "earth threshold"
+    MOON_THRESH = "moon threshold"
+    SUN_THRESH = "sun threshold"
+
     OUTPUT_CHANNEL = "output_channel"
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -137,9 +137,9 @@ class CommandKwargs(StringEnum):
     IGNORE = "ignore"
     PASSWORD = "password"
 
-    EARTH_THRESH = "earth threshold"
-    MOON_THRESH = "moon threshold"
-    SUN_THRESH = "sun threshold"
+    EARTH_THRESH = "earth_threshold"
+    MOON_THRESH = "moon_threshold"
+    SUN_THRESH = "sun_threshold"
 
     OUTPUT_CHANNEL = "output_channel"
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -405,4 +405,5 @@ class CommandEnum(IntEnum):
     LongString = 56
 
     IgnoreLowBatt = 60
+    SetEMSThresh = 61
     CeaseComms = 170


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR:
- Addresses Jira ticket [CISLUNAR-154](https://cislunarsoftware.atlassian.net/browse/CISLUNAR-154)     <!-- Replace XX with JIRA ticket number -->
- Implements a new command to change the Earth/Sun/Moon threshold to help with testing the find_with_hough_transform_and_contours.findBody() opnav find algorithm


### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
- Tested with a unit test
- Find test in tests/command_test.py test_setEMSThresh()
- Tested uplinked data and downlinked


### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
- Looking through the other commands, one concern/thought I had was if this command may be redundant, given the existence of the set_param() command, which can change any single command. However, incorporating a single command for changing all of the parameters of only a particular find algorithm may be of use for testing


### Comments
- [x] Add an x between the brackets if you commented your code well!

